### PR TITLE
[Issue#1] Remove unnecessary always show pass global settings

### DIFF
--- a/lib/data/datasource/account_preference_local_data_source.dart
+++ b/lib/data/datasource/account_preference_local_data_source.dart
@@ -8,8 +8,6 @@ abstract class AccountPreferenceLocalDataSource {
 
   Future<void> saveRequireLogin(bool require);
 
-  Future<void> saveAlwaysShowPassword(bool alwaysShow);
-
   Future<void> deleteAll();
 
   Future<void> enableDarkMode(bool enable);
@@ -29,9 +27,6 @@ class AccountPreferenceLocalDataSourceImpl
       requireLogin:
           sharedPrefs.getBool(AccountPreferenceEntity.keyRequireLogin) ??
               AccountPreference.requireLoginDefault,
-      alwaysShowPasswords:
-          sharedPrefs.getBool(AccountPreferenceEntity.keyAlwaysShowPasswords) ??
-              AccountPreference.alwaysShowPasswordsDefault,
       enableDarkMode:
           sharedPrefs.getBool(AccountPreferenceEntity.keyEnableDarkMode) ??
               AccountPreference.enableDarkModeDefault,
@@ -45,13 +40,6 @@ class AccountPreferenceLocalDataSourceImpl
   Future<void> saveRequireLogin(bool require) async {
     final sharedPrefs = await _prefs;
     sharedPrefs.setBool(AccountPreferenceEntity.keyRequireLogin, require);
-  }
-
-  @override
-  Future<void> saveAlwaysShowPassword(bool alwaysShow) async {
-    final sharedPrefs = await _prefs;
-    sharedPrefs.setBool(
-        AccountPreferenceEntity.keyAlwaysShowPasswords, alwaysShow);
   }
 
   @override

--- a/lib/data/entity/account_preference_entity.dart
+++ b/lib/data/entity/account_preference_entity.dart
@@ -7,19 +7,16 @@ part 'account_preference_entity.g.dart';
 @CopyWith()
 class AccountPreferenceEntity {
   static const keyRequireLogin = 'requireLogin';
-  static const keyAlwaysShowPasswords = 'alwaysShowPasswords';
   static const keyEnableDarkMode = 'enableDarkMode';
   static const keyLanguageCode = 'languageCode';
 
   AccountPreferenceEntity({
     this.requireLogin = AccountPreference.requireLoginDefault,
-    this.alwaysShowPasswords = AccountPreference.alwaysShowPasswordsDefault,
     this.enableDarkMode = AccountPreference.enableDarkModeDefault,
     this.languageCode = AccountPreference.languageCodeDefault,
   });
 
   final bool requireLogin;
-  final bool alwaysShowPasswords;
   final bool enableDarkMode;
   final String languageCode;
 
@@ -32,12 +29,6 @@ class AccountPreferenceEntity {
                   (element) => element.name == PreferenceName.requirePass)
               ?.value ??
           AccountPreference.requireLoginDefault,
-      // Always show password
-      alwaysShowPasswords: preference.items
-              .firstWhereOrNull(
-                  (element) => element.name == PreferenceName.alwaysShowPass)
-              ?.value ??
-          AccountPreference.alwaysShowPasswordsDefault,
       // Dark mode
       enableDarkMode: preference.items
               .firstWhereOrNull(
@@ -58,10 +49,6 @@ class AccountPreferenceEntity {
           AccountPreferenceItem(
             name: PreferenceName.requirePass,
             value: requireLogin,
-          ),
-          AccountPreferenceItem(
-            name: PreferenceName.alwaysShowPass,
-            value: alwaysShowPasswords,
           ),
           AccountPreferenceItem(
             name: PreferenceName.enableDarkMode,

--- a/lib/data/entity/account_preference_entity.g.dart
+++ b/lib/data/entity/account_preference_entity.g.dart
@@ -7,8 +7,6 @@ part of 'account_preference_entity.dart';
 // **************************************************************************
 
 abstract class _$AccountPreferenceEntityCWProxy {
-  AccountPreferenceEntity alwaysShowPasswords(bool alwaysShowPasswords);
-
   AccountPreferenceEntity enableDarkMode(bool enableDarkMode);
 
   AccountPreferenceEntity languageCode(String languageCode);
@@ -22,7 +20,6 @@ abstract class _$AccountPreferenceEntityCWProxy {
   /// AccountPreferenceEntity(...).copyWith(id: 12, name: "My name")
   /// ````
   AccountPreferenceEntity call({
-    bool? alwaysShowPasswords,
     bool? enableDarkMode,
     String? languageCode,
     bool? requireLogin,
@@ -35,10 +32,6 @@ class _$AccountPreferenceEntityCWProxyImpl
   final AccountPreferenceEntity _value;
 
   const _$AccountPreferenceEntityCWProxyImpl(this._value);
-
-  @override
-  AccountPreferenceEntity alwaysShowPasswords(bool alwaysShowPasswords) =>
-      this(alwaysShowPasswords: alwaysShowPasswords);
 
   @override
   AccountPreferenceEntity enableDarkMode(bool enableDarkMode) =>
@@ -61,18 +54,11 @@ class _$AccountPreferenceEntityCWProxyImpl
   /// AccountPreferenceEntity(...).copyWith(id: 12, name: "My name")
   /// ````
   AccountPreferenceEntity call({
-    Object? alwaysShowPasswords = const $CopyWithPlaceholder(),
     Object? enableDarkMode = const $CopyWithPlaceholder(),
     Object? languageCode = const $CopyWithPlaceholder(),
     Object? requireLogin = const $CopyWithPlaceholder(),
   }) {
     return AccountPreferenceEntity(
-      alwaysShowPasswords:
-          alwaysShowPasswords == const $CopyWithPlaceholder() ||
-                  alwaysShowPasswords == null
-              ? _value.alwaysShowPasswords
-              // ignore: cast_nullable_to_non_nullable
-              : alwaysShowPasswords as bool,
       enableDarkMode: enableDarkMode == const $CopyWithPlaceholder() ||
               enableDarkMode == null
           ? _value.enableDarkMode

--- a/lib/data/repository/account_pref_repo_impl.dart
+++ b/lib/data/repository/account_pref_repo_impl.dart
@@ -25,9 +25,6 @@ class AccountPrefRepoImpl extends AccountPrefRepo {
       case PreferenceName.requirePass:
         return _accountPreferenceLocalDataSource
             .saveRequireLogin(value as bool);
-      case PreferenceName.alwaysShowPass:
-        return _accountPreferenceLocalDataSource
-            .saveAlwaysShowPassword(value as bool);
       case PreferenceName.enableDarkMode:
         return _accountPreferenceLocalDataSource.enableDarkMode(value as bool);
       case PreferenceName.languageCode:

--- a/lib/domain/model/account_preference.dart
+++ b/lib/domain/model/account_preference.dart
@@ -6,7 +6,6 @@ part 'account_preference.g.dart';
 @CopyWith()
 class AccountPreference extends Equatable {
   static const requireLoginDefault = true;
-  static const alwaysShowPasswordsDefault = false;
   static const enableDarkModeDefault = false;
   static const languageCodeDefault = 'en';
 
@@ -18,10 +17,6 @@ class AccountPreference extends Equatable {
     AccountPreferenceItem(
       name: PreferenceName.requirePass,
       value: requireLoginDefault,
-    ),
-    AccountPreferenceItem(
-      name: PreferenceName.alwaysShowPass,
-      value: alwaysShowPasswordsDefault,
     ),
     AccountPreferenceItem(
       name: PreferenceName.enableDarkMode,
@@ -57,7 +52,6 @@ class AccountPreference extends Equatable {
 
 enum PreferenceName {
   requirePass,
-  alwaysShowPass,
   enableDarkMode,
   languageCode,
 }

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -72,8 +72,6 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("What is your name?"),
         "noResults": MessageLookupByLibrary.simpleMessage("No results found"),
         "passSaverHyphen": MessageLookupByLibrary.simpleMessage("PASS-SAVER"),
-        "prefAlwaysShow": MessageLookupByLibrary.simpleMessage(
-            "Always show account names and passwords"),
         "prefDarkMode":
             MessageLookupByLibrary.simpleMessage("Enable dark mode"),
         "prefRequireLogin":

--- a/lib/generated/intl/messages_vi.dart
+++ b/lib/generated/intl/messages_vi.dart
@@ -73,8 +73,6 @@ class MessageLookup extends MessageLookupByLibrary {
         "noResults":
             MessageLookupByLibrary.simpleMessage("Không tìm thấy kết quả"),
         "passSaverHyphen": MessageLookupByLibrary.simpleMessage("PASS-SAVER"),
-        "prefAlwaysShow": MessageLookupByLibrary.simpleMessage(
-            "Luôn hiển thị tên tài khoản và mật khẩu"),
         "prefDarkMode": MessageLookupByLibrary.simpleMessage("Bật theme tối"),
         "prefRequireLogin": MessageLookupByLibrary.simpleMessage(
             "Yêu cầu mật khẩu khi đăng nhập"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -410,16 +410,6 @@ class S {
     );
   }
 
-  /// `Always show account names and passwords`
-  String get prefAlwaysShow {
-    return Intl.message(
-      'Always show account names and passwords',
-      name: 'prefAlwaysShow',
-      desc: '',
-      args: [],
-    );
-  }
-
   /// `Enable dark mode`
   String get prefDarkMode {
     return Intl.message(

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -41,7 +41,6 @@
     "preferences": "Preferences",
     "deleteAccount": "Delete Account",
     "prefRequireLogin": "Require login on open app",
-    "prefAlwaysShow": "Always show account names and passwords",
     "prefDarkMode": "Enable dark mode",
     "savePassTitle": "Save your Account and Password",
     "savePassSubTitle": "Your password is only saved locally, you can use network activity to check no Internet connection is establish",

--- a/lib/l10n/intl_vi.arb
+++ b/lib/l10n/intl_vi.arb
@@ -41,7 +41,6 @@
     "preferences": "Cài đặt",
     "deleteAccount": "Xoá tài khoản",
     "prefRequireLogin": "Yêu cầu mật khẩu khi đăng nhập",
-    "prefAlwaysShow": "Luôn hiển thị tên tài khoản và mật khẩu",
     "prefDarkMode": "Bật theme tối",
     "savePassTitle": "Lưu tài khoản và mật khẩu",
     "savePassSubTitle": "Mật khẩu của bạn chỉ được lưu trong máy, bạn có thể kiểm tra hoạt động Internet của máy để xác nhận",

--- a/lib/presentation/page/password/list/bloc/password_bloc.dart
+++ b/lib/presentation/page/password/list/bloc/password_bloc.dart
@@ -13,7 +13,6 @@ import 'package:flutter_password_saver/presentation/page/password/list/bloc/pass
 import 'package:flutter_password_saver/presentation/page/password/list/bloc/password_state.dart';
 import 'package:flutter_password_saver/presentation/utils/load_state.dart';
 import 'package:injectable/injectable.dart';
-import 'package:collection/collection.dart';
 
 @injectable
 class PasswordBloc extends Bloc<PasswordEvent, PasswordState> {
@@ -44,13 +43,6 @@ class PasswordBloc extends Bloc<PasswordEvent, PasswordState> {
 
   AccountPreference? _accountPreference;
   AccountPreference? get accountPreference => _accountPreference;
-
-  bool get prefAlwaysShowPassword =>
-      accountPreference?.items
-          .firstWhereOrNull(
-              (element) => element.name == PreferenceName.alwaysShowPass)
-          ?.value ??
-      AccountPreference.alwaysShowPasswordsDefault;
 
   FutureOr<void> _getPasswords(
     GetPasswordEvent event,

--- a/lib/presentation/page/password/list/password_page.dart
+++ b/lib/presentation/page/password/list/password_page.dart
@@ -80,7 +80,6 @@ class _PasswordPageState extends State<PasswordPage> {
           return PasswordListItem(
             key: ObjectKey(item),
             password: item,
-            forceShow: _bloc.prefAlwaysShowPassword,
             onChangeSetting: (settings) {
               _bloc.add(
                 UpdateSettingsEvent(

--- a/lib/presentation/page/password/list/widget/password_list_item.dart
+++ b/lib/presentation/page/password/list/widget/password_list_item.dart
@@ -19,12 +19,10 @@ class PasswordListItem extends StatefulWidget {
   const PasswordListItem({
     Key? key,
     required this.password,
-    this.forceShow = false,
     this.onChangeSetting,
   }) : super(key: key);
 
   final Password password;
-  final bool forceShow;
   final Function(PasswordSettings passwordSettings)? onChangeSetting;
 
   @override
@@ -54,11 +52,6 @@ class _PasswordListItemState extends State<PasswordListItem> {
     }
 
     if (passSettingAlwaysShow == true) {
-      _alwaysShow = true;
-      _contentVisible = true;
-    } else if (passSettingAlwaysShow == null && widget.forceShow) {
-      // Only check null, to respect individual's password preference
-      // over universal settings
       _alwaysShow = true;
       _contentVisible = true;
     }

--- a/lib/presentation/page/preferences/widget/pref_item_switch_widget.dart
+++ b/lib/presentation/page/preferences/widget/pref_item_switch_widget.dart
@@ -53,8 +53,6 @@ class _PrefItemSwitcherState extends State<PrefItemSwitcher> {
     switch (widget.preferenceItem.name) {
       case PreferenceName.requirePass:
         return Text(S().prefRequireLogin);
-      case PreferenceName.alwaysShowPass:
-        return Text(S().prefAlwaysShow);
       case PreferenceName.enableDarkMode:
         return Text(S().prefDarkMode);
       default:


### PR DESCRIPTION
Resolves [Issue#1](https://github.com/ngthailam/flutter_password_saver/issues/1)

Because global settings does nothing, as it is overriden by local settings